### PR TITLE
Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ var joinedString = client.RemoteConcat("Hello", " World");
 Console.WriteLine(joinedString); //Gives us "Hello World"
 ```
 
+## Encryption
+
+As for version 6.3.0, symmetric encryption is provided by AES.
+
+To enable encryption, `SetEncryptionKey(string key)` must be called on both the client and server
+providing the same `key`.
+
+Note that this is not really safe for scenarios where the preshared key is in the public domain, or a
+public client.  It is supposed to stop snooping from server-to-server.  A more public-domain friendly 
+solution may be added later.
+
 ## Coming (hopefully) soon:
 
- - Encryption/Security
  - ServiceCollection registration

--- a/qRPC/Client/QrpcClient.cs
+++ b/qRPC/Client/QrpcClient.cs
@@ -18,6 +18,7 @@ namespace qRPC.Client
         readonly int _port;
         readonly string _hostname;
         readonly Encoding _encoding;
+        string _encryptionKey = null;
         public QrpcClient(int port, string hostname, Encoding encoding)
         {
             _port = port;
@@ -59,9 +60,7 @@ namespace qRPC.Client
                     Arguments = invocation.Arguments.Select(a => JsonSerializer.Serialize(a)).ToArray()
                 };
 
-                //stream.WriteObjectToStream(message, _encoding);
-
-                stream.WriteObjectToStream(message, _encoding);
+                stream.WriteObjectToStream(message, _encoding, _encryptionKey);
 
                 int checks = 0;
                 while ((tcp.Available == 0 || !tcp.Connected) && checks <= 10)
@@ -72,7 +71,7 @@ namespace qRPC.Client
                 object obj = null;
                 if (tcp.Connected)
                 {
-                    obj = stream.ReadObjectFromStream(_encoding, invocation.Method.ReturnType);
+                    obj = stream.ReadObjectFromStream(_encoding, invocation.Method.ReturnType, _encryptionKey);
                 }
                 else
                     throw new TimeoutException("qRPC Client timed out.  Status is disconnected.");
@@ -81,6 +80,11 @@ namespace qRPC.Client
                 return obj;
             }
 
+        }
+
+        public void SetEncryptionKey(string key)
+        {
+            _encryptionKey = key;
         }
 
     }

--- a/qRPC/Transport/AesOperation.cs
+++ b/qRPC/Transport/AesOperation.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.VisualBasic;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace qRPC.Transport
+{
+    internal static class AesOperation
+    {
+        public static string Encrypt(this string data, string key)
+        {
+            using Aes aes = Aes.Create();
+            aes.Key = Encoding.UTF8.GetBytes(key);
+            aes.GenerateIV();
+            
+            ICryptoTransform transform = aes.CreateEncryptor();
+
+            using MemoryStream ms = new MemoryStream();
+            using CryptoStream cs = new(ms, transform, CryptoStreamMode.Write);
+            using StreamWriter sw = new(cs);
+
+            sw.Write(data);
+            sw.Flush();
+            cs.FlushFinalBlock();
+            byte[] array = ms.ToArray();
+            
+            string siv = Convert.ToBase64String(aes.IV);
+            string dataPart = Convert.ToBase64String(array);
+
+            return $"{siv}.{dataPart}";
+        }
+
+
+        public static string Decrypt(this string input, string key)
+        {
+            string[] parts = input.Split('.');
+            if (parts.Length != 2)
+                throw new ArgumentException("Decryption input format incorrect.");
+
+            byte[] iv = Convert.FromBase64String(parts[0]);
+            byte[] data = Convert.FromBase64String(parts[1]);
+
+            using Aes aes = Aes.Create();
+            aes.Key = Encoding.UTF8.GetBytes(key);
+            aes.IV = iv;
+
+            ICryptoTransform transform = aes.CreateDecryptor();
+
+            using MemoryStream ms = new MemoryStream(data);
+            using CryptoStream cs = new(ms, transform, CryptoStreamMode.Read);
+            using StreamReader sr = new StreamReader(cs);
+            
+            return sr.ReadToEnd();
+        }
+
+        public static string EncryptIfKeyProvided(this string data, string key)
+        {
+            if (!string.IsNullOrWhiteSpace(key))
+                return data.Encrypt(key);
+            return data;
+        }
+
+        public static string DecryptIfKeyProvided(this string data, string key)
+        {
+            if (!string.IsNullOrWhiteSpace(key))
+                return data.Decrypt(key);
+            return data;
+        }
+    }
+}

--- a/qRPC/Transport/TransportExtensions.cs
+++ b/qRPC/Transport/TransportExtensions.cs
@@ -8,35 +8,43 @@ namespace qRPC.Transport
 {
     public static class TransportExtensions
     {
-        public static void WriteObjectToStream(this Stream stream, object obj, Encoding encoding)
+        public static void WriteObjectToStream(this Stream stream, object obj, Encoding encoding, string encryptionKey = null)
         {
             using(var bw = new BinaryWriter(stream, encoding, true))
             {
-                bw.Write(JsonSerializer.Serialize(obj));
+                bw.Write(JsonSerializer.Serialize(obj).EncryptIfKeyProvided(encryptionKey));
                 bw.Flush();
             }
         }
 
-        public static object ReadObjectFromStream(this Stream stream, Encoding encoding, Type T)
+        
+        public static object ReadObjectFromStream(this Stream stream, Encoding encoding, Type T, string encryptionKey = null)
         {
             string data = null;
             var br = new BinaryReader(stream, encoding, true);
             data = br.ReadString();
+            data = data.DecryptIfKeyProvided(encryptionKey);
             if (T == typeof(void))
                 return default;
             return JsonSerializer.Deserialize(data,T);
         }
 
-        public static T ReadObjectFromStream<T>(this Stream stream, Encoding encoding)
+        public static T ReadObjectFromStream<T>(this Stream stream, Encoding encoding, string encryptionKey = null)
         {
             string data = null;
             var br = new BinaryReader(stream, encoding, true);
-            data = br.ReadString();
+            data = br.ReadString().DecryptIfKeyProvided(encryptionKey);
 
             if (typeof(T) == typeof(void))
                 return default;
 
             return JsonSerializer.Deserialize<T>(data);
+        }
+
+        public static string ReadStringFromStream(this Stream stream, Encoding encoding)
+        {
+            var br = new BinaryReader(stream, encoding, true);
+            return br.ReadString();
         }
     }
 }

--- a/qRPC/qRPC.csproj
+++ b/qRPC/qRPC.csproj
@@ -8,7 +8,7 @@
     <Description>Quick Remote Procedure Calls using BSON and CASTLE Proxies via a common interface implementation.  Still in infancy, this project was a personal response to gRPC being too much fuss.</Description>
     <Copyright>Daniel James Thorne 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.2.1</Version>
+    <Version>6.3.0</Version>
     <RepositoryUrl>https://github.com/rombethor/qRPC</RepositoryUrl>
     <PackageProjectUrl>https://github.com/rombethor/qRPC</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Data transferred in optionally encrypted using a preshared key, providing a layer of security to what is otherwise plain text.

Encryption is enabled on either the client or server by calling `SetEncryptionKey(string key)`.

The encryption is AES and the data sent is preceeded by a randomised Initialisation Vector (IV).

Admittedly, this kind of encryption is only safe in limited scenarios (server-to-server) because a preshared key could not be provided to a public client.  This project has always been geared towards RPC within closed environments, such as kubernetes clusters.  A more public-friendly solution may be added in a later version.